### PR TITLE
User削除API 作成

### DIFF
--- a/application/server/handler/userHandler/userDelete.go
+++ b/application/server/handler/userHandler/userDelete.go
@@ -1,0 +1,39 @@
+package userHandler
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"ToDoList/application/server/response"
+	"ToDoList/domain/model/userModel"
+)
+
+type UserDeleteRequest struct {
+	Name     string `json:"name"`
+	PassWord string `json:"password"`
+}
+
+func HandleUserDelete() http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+
+		// リクエストBodyから更新後情報を取得
+		var requestBody UserSigninRequest
+		if err := json.NewDecoder(request.Body).Decode(&requestBody); err != nil {
+			log.Println(err)
+			response.InternalServerError(writer, "Internal Server Error")
+			return
+		}
+
+		// ユーザデータを検索する
+		err := userModel.UpdateUserExistence(
+			requestBody.Name,
+			requestBody.PassWord,
+		)
+		if err != nil {
+			log.Println(err)
+			response.InternalServerError(writer, "Internal Server Error")
+			return
+		}
+	}
+}


### PR DESCRIPTION
# 実装したこと
User削除APIハンドラ作成

## 追加
`././server/handler/userHandler/userSignin.go`にエンドポイントに該当する関数`HandleUserDelete`を作成。

### `HandleUserDelete`
domain層の`user.go`に`Name`,`PassWord`を送る。